### PR TITLE
use .lcomm to declare vars in .bss section

### DIFF
--- a/arch/x86/boot0/boot0.S
+++ b/arch/x86/boot0/boot0.S
@@ -11,8 +11,7 @@ msg_please_reboot:
     .asciz "An error was encountered, please reboot"
 
     .section .bss
-boot_drv:
-    .byte 1
+    .lcomm boot_drv , 1
 
     .section .data
 #ifdef BOOTLOADER_PROTECTED_MODE_ENABLED

--- a/arch/x86/bootstrap.S
+++ b/arch/x86/bootstrap.S
@@ -7,8 +7,7 @@
     .section .bss
 
     .global boot_drive_nb
-boot_drive_nb:
-    .byte 1
+    .lcomm boot_drive_nb , 1
 
     .section .text
 


### PR DESCRIPTION
I got the error: `bootstrap.S:11: Error: attempt to store non-zero value in section '.bss'`

When trying to build on i386-elf-gcc (GCC) 9.2.0

This change fixed the error since it declare the variables in BSS without assigning a value.